### PR TITLE
Cache, clear_cache, and disable_kiosk

### DIFF
--- a/kiosk-mode.js
+++ b/kiosk-mode.js
@@ -28,8 +28,8 @@ const getSidebarElem = () => {
 
 // Clear cache if requested
 if (window.location.href.includes("clear_cache")) {
-  window.localStorage.removeItem("kmHeader");
-  window.localStorage.removeItem("kmSidebar");
+  window.localStorage.setItem("kmHeader", "false");
+  window.localStorage.setItem("kmSidebar", "false");
 }
 
 // Retrieve local storage cache as bool
@@ -37,10 +37,7 @@ const hide_header = window.localStorage.getItem("kmHeader") == "true";
 const hide_sidebar = window.localStorage.getItem("kmSidebar") == "true";
 
 // If any from local storage are true
-const run = hide_sidebar || hide_header;
-
-console.log(hide_header, hide_sidebar, run);
-console.log(locIncludes(["kiosk", "hide_header", "hide_sidebar"]) || run);
+const run = !!(hide_sidebar || hide_header);
 
 const kiosk_mode = () => {
   setTimeout(() => {
@@ -97,6 +94,8 @@ new MutationObserver(kiosk_mode).observe(
     .shadowRoot.querySelector("partial-panel-resolver"),
   { childList: true }
 );
+
+kiosk_mode();
 
 console.info(
   `%c  KIOSK-MODE   \n%c Version 1.1.0 `,

--- a/kiosk-mode.js
+++ b/kiosk-mode.js
@@ -26,42 +26,77 @@ const getSidebarElem = () => {
   }
 };
 
-setTimeout(() => {
-  // Only run if location includes one of the keywords.
-  if (locIncludes(["kiosk", "hide_header", "hide_sidebar"])) {
-    const header = getHeaderElem();
-    const sidebar = getSidebarElem();
-    // Insert style element for kiosk or hide_header options.
-    if (locIncludes(["kiosk", "hide_header"]) && header) {
-      const style = document.createElement("style");
-      style.setAttribute("id", "kiosk_mode");
-      style.innerHTML = `
-            #view {
-              min-height: 100vh !important;
-            }
-            app-header {
-              display: none;
-            }
-          `;
-      header.appendChild(style);
+// Clear cache if requested
+if (window.location.href.includes("clear_cache")) {
+  window.localStorage.removeItem("kmHeader");
+  window.localStorage.removeItem("kmSidebar");
+}
+
+// Retrieve local storage cache as bool
+const hide_header = window.localStorage.getItem("kmHeader") == "true";
+const hide_sidebar = window.localStorage.getItem("kmSidebar") == "true";
+
+// If any from local storage are true
+const run = hide_sidebar || hide_header;
+
+console.log(hide_header, hide_sidebar, run);
+console.log(locIncludes(["kiosk", "hide_header", "hide_sidebar"]) || run);
+
+const kiosk_mode = () => {
+  setTimeout(() => {
+    if (window.location.href.includes("disable_kiosk")) return;
+    // Only run if location includes one of the keywords.
+    if (locIncludes(["kiosk", "hide_header", "hide_sidebar"]) || run) {
+      const header = getHeaderElem();
+      const sidebar = getSidebarElem();
+      // Insert style element for kiosk or hide_header options.
+      if ((locIncludes(["kiosk", "hide_header"]) || hide_header) && header) {
+        const style = document.createElement("style");
+        style.setAttribute("id", "kiosk_mode");
+        style.innerHTML = `
+          #view {
+            min-height: 100vh !important;
+          }
+          app-header {
+            display: none;
+          }
+        `;
+        header.appendChild(style);
+        // Set local storage cache for hiding header
+        if (window.location.href.includes("cache")) {
+          window.localStorage.setItem("kmHeader", "true");
+        }
+      }
+      // Insert style element for kiosk or hide_sidebar options.
+      if ((locIncludes(["kiosk", "hide_sidebar"]) || hide_sidebar) && sidebar) {
+        const style = document.createElement("style");
+        style.setAttribute("id", "kiosk_mode");
+        style.innerHTML = `
+          :host {
+            --app-drawer-width: 0 !important;
+          }
+          #drawer {
+            display: none;
+          }
+        `;
+        sidebar.appendChild(style);
+        // Set local storage cache for hiding sidebar
+        if (window.location.href.includes("cache")) {
+          window.localStorage.setItem("kmSidebar", "true");
+        }
+      }
     }
-    // Insert style element for kiosk or hide_sidebar options.
-    if (locIncludes(["kiosk", "hide_sidebar"]) && sidebar) {
-      const style = document.createElement("style");
-      style.setAttribute("id", "kiosk_mode");
-      style.innerHTML = `
-            :host {
-              --app-drawer-width: 0 !important;
-            }
-            #drawer {
-              display: none;
-            }
-          `;
-      sidebar.appendChild(style);
-    }
-  }
-  window.dispatchEvent(new Event("resize"));
-}, 200);
+    window.dispatchEvent(new Event("resize"));
+  }, 200);
+};
+
+new MutationObserver(kiosk_mode).observe(
+  document
+    .querySelector("home-assistant")
+    .shadowRoot.querySelector("home-assistant-main")
+    .shadowRoot.querySelector("partial-panel-resolver"),
+  { childList: true }
+);
 
 console.info(
   `%c  KIOSK-MODE   \n%c Version 1.1.0 `,

--- a/kiosk-mode.js
+++ b/kiosk-mode.js
@@ -47,7 +47,11 @@ const kiosk_mode = () => {
       const header = getHeaderElem();
       const sidebar = getSidebarElem();
       // Insert style element for kiosk or hide_header options.
-      if ((locIncludes(["kiosk", "hide_header"]) || hide_header) && header) {
+      if (
+        (locIncludes(["kiosk", "hide_header"]) || hide_header) &&
+        header &&
+        !header.querySelector("#kiosk_mode")
+      ) {
         const style = document.createElement("style");
         style.setAttribute("id", "kiosk_mode");
         style.innerHTML = `
@@ -65,7 +69,11 @@ const kiosk_mode = () => {
         }
       }
       // Insert style element for kiosk or hide_sidebar options.
-      if ((locIncludes(["kiosk", "hide_sidebar"]) || hide_sidebar) && sidebar) {
+      if (
+        (locIncludes(["kiosk", "hide_sidebar"]) || hide_sidebar) &&
+        sidebar &&
+        !sidebar.querySelector("#kiosk_mode")
+      ) {
         const style = document.createElement("style");
         style.setAttribute("id", "kiosk_mode");
         style.innerHTML = `


### PR DESCRIPTION
This one will need some explaining in the readme if/when you merge and release.

This adds a cache feature. If you add `cache` to the end of the URL (or anywhere really) it will cache your preferences and will persist between views and dashboards. Example: `?hide_header&cache`. That will make it so that every view and dashboard will hide the header (works for all options).

To help with that new feature there are two more keywords added as well. Putting `?clear_cache` in the URL will clear those cached preferences and adding `?disable_kiosk` will temporarily disable any modification.

